### PR TITLE
IO fix

### DIFF
--- a/src/main/java/com/surftools/BeanstalkClientImpl/ProtocolHandler.java
+++ b/src/main/java/com/surftools/BeanstalkClientImpl/ProtocolHandler.java
@@ -143,8 +143,8 @@ public class ProtocolHandler {
 		
 		try {
 			byte[] data = new byte[length];
-                        int off = 0;
-                        int toRead = length-off;
+			int off = 0;
+			int toRead = length-off;
 			while (toRead > 0) {
 				int readLength = is.read( data, off, toRead);
 				if (readLength == -1)


### PR DESCRIPTION
Alexander,

Great job. I've pushed in your changes to 1.2.2. Thanks for your effort.

Bob

Bob,

Remember I wrote you about BeanstalkException("The end of InputStream reached...") that we experience from time to time. I have a theory. When the jobs are relatively large, there is a change they will not fit into network buffer and only one `read` call is not sufficient to read the whole message. So I believe it's the reason of the behavior we see.

Please review and consider the following patch. I'd be grateful if you tried to reproduce the error using existing library and review the fix...

Best,
Alexander.
