### PR TITLE
Slow Beanstalk response times under Linux

### DIFF
--- a/src/main/java/com/surftools/BeanstalkClientImpl/ProtocolHandler.java
+++ b/src/main/java/com/surftools/BeanstalkClientImpl/ProtocolHandler.java
@@ -54,23 +54,20 @@ public class ProtocolHandler {
 		validateRequest(request);
 		
 		Response response = null;
-		OutputStream os = null;
 		InputStream is = null;
 		PrintWriter out = null;
 
 		try {			
-			os = socket.getOutputStream();
-			out = new PrintWriter(os);
-
-			out.print(request.getCommand() + "\r\n");
-				if (request.getData() != null) {
-				out.flush();
-				os.write(request.getData());
-				out.print("\r\n");
+			String command = request.getCommand() + "\r\n";
+			if (request.getData() != null) {
+				command += new String(request.getData());
+				command += "\r\n";
 			}
+
+			out = new PrintWriter(socket.getOutputStream());
+			out.write(command);
 			out.flush();
-			os.flush();
-							
+
 			is = socket.getInputStream();
 			String line = new String(readInputStream(is, 0 ));
 	


### PR DESCRIPTION
Hi Bob,

I noticed an issue with the Beanstalk client the other day occurring in our production cluster.  We were observing job enqueue times of 40ms+, which resulted in a couple of our servers becoming heavily backed up.  For reference, the Python beanstalkc client averages enqueue times of 0.5 - 1.5ms.

After some instrumentation and investigating the problem, I discovered that the processRequest method in ProtocolHandler was calling .flush() three times when it need only be called once.  On Mac OS X (and likely, other operating systems using the BSD TCP stack), this resulted in no appreciable delay -- jobs were enqueued within 0-1ms as expected.  However, under Linux (at least Ubuntu 10.04 LTS 64-bit), the extra calls to flush() resulted in a substantial delay and enqueue time of 40 - 50ms+, even with Beanstalk running locally on the same server.

The changes in this patch are minimal and formatted to match the existing code. I've tested this on Linux and Mac OS X, but not Windows. The test suite included passes fine and builds properly. If you have a Windows machine available, it would probably be good to test there before integrating. If not, I can set up a Java development environment on one and test myself if you'd prefer.

Regards,
- Scott
