### PR TITLE
testUseBlockIO

### DIFF
--- a/src/test/java/com/surftools/BeanstalkClientImpl/ClientImplTest.java
+++ b/src/test/java/com/surftools/BeanstalkClientImpl/ClientImplTest.java
@@ -887,6 +887,8 @@ public class ClientImplTest extends TestCase {
 				client.delete(job.getJobId());
 
 				popWatchedTubes(client, tubeNames);
+				
+				client.close();
 			}
 		}
 	}


### PR DESCRIPTION
This test was creating enough open file descriptors on my mac to cause trouble, causing the server to spit out:
beanstalkd: prot.c:1800 in h_accept: accept(): Too many open files
beanstalkd: net.c:106 in brake: too many connections; putting on the brakes

It's a system configuration error, sure, but seems to me if this many connections are going to be opened they should close.

As always thanks for the sweet library.
