### PR TITLE
Improve map parsing

### DIFF
--- a/src/main/java/com/surftools/BeanstalkClientImpl/ProtocolHandler.java
+++ b/src/main/java/com/surftools/BeanstalkClientImpl/ProtocolHandler.java
@@ -250,7 +250,7 @@ public class ProtocolHandler {
 				if (line.length() == 0) {
 					break;
 				}
-				String[] values = line.split(":");
+				String[] values = line.split(": ");
 				if (values.length != 2) {
 					continue;
 				}


### PR DESCRIPTION
Another tiny little change.  This was bothering me because I was trying to parse numeric output from stats and found there was always a space before the number.  This seems to conform to the output of the stats command, so I thought I'd save us all the trouble of ripping it out.

Thanks!
Pat Shields
